### PR TITLE
Adding missing headers for XCode 12 compilation

### DIFF
--- a/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
+++ b/lib/c_glib/src/thrift/c_glib/protocol/thrift_protocol_decorator.h
@@ -65,8 +65,15 @@ struct _ThriftProtocolDecoratorClass
 };
 
 /* used by THRIFT_TYPE_PROTOCOL_DECORATOR */
-GType thrift_protocol_decorator_get_type (void);
+GType
+thrift_protocol_decorator_get_type (void);
 
+gint32
+thrift_protocol_decorator_write_message_begin (
+    ThriftProtocol *protocol,
+    const gchar *name,
+    const ThriftMessageType message_type,
+    const gint32 seqid, GError **error);
 G_END_DECLS
 
 #endif /* _THRIFT_PROTOCOL_DECORATOR_H */

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_socket.h
@@ -67,6 +67,32 @@ struct _ThriftSocketClass
 /* used by THRIFT_TYPE_SOCKET */
 GType thrift_socket_get_type (void);
 
+/**
+ * Check if the socket is open and ready to send and receive
+ * @param transport
+ * @return true if open
+ */
+gboolean
+thrift_socket_is_open (ThriftTransport *transport);
+
+/**
+ * Open connection if required and set the socket to be ready to send and receive
+ * @param transport
+ * @param error
+ * @return true if operation was correct
+ */
+gboolean
+thrift_socket_open (ThriftTransport *transport, GError **error);
+
+/**
+ * Close connection if required
+ * @param transport
+ * @param error
+ * @return true if operation was correct
+ */
+gboolean
+thrift_socket_close (ThriftTransport *transport, GError **error);
+
 G_END_DECLS
 
 #endif

--- a/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
+++ b/lib/c_glib/src/thrift/c_glib/transport/thrift_ssl_socket.h
@@ -188,6 +188,15 @@ thrift_ssl_socket_is_open (ThriftTransport *transport);
 gboolean
 thrift_ssl_socket_open (ThriftTransport *transport, GError **error);
 
+/**
+ * Close connection if required
+ * @param transport
+ * @param error
+ * @return true if operation was correct
+ */
+gboolean
+thrift_ssl_socket_close (ThriftTransport *transport, GError **error);
+
 
 /**
  * @brief Initialization function
@@ -213,6 +222,9 @@ thrift_ssl_socket_initialize_openssl(void);
  */
 void
 thrift_ssl_socket_finalize_openssl(void);
+
+gboolean
+thrift_ssl_socket_authorize(ThriftTransport * transport, GError **error);
 
 G_END_DECLS
 #endif


### PR DESCRIPTION
Added previously undeclared functions to avoid compilation errors on XCode 12+. Previously these missing declarations were compiler warnings but are no longer.
